### PR TITLE
Delete Home link from navbar

### DIFF
--- a/src/components/Navbar/Authenticated.tsx
+++ b/src/components/Navbar/Authenticated.tsx
@@ -8,10 +8,6 @@ const Authenticated : FC = () => (
     (
         <div id="admin-navbar" className="navbar-menu">
             <div className="navbar-start">
-                <a className="navbar-item" href="/">
-                    Home
-                </a>
-
                 <Link to="/book-list/1" className="navbar-item">
                     Books
                 </Link>


### PR DESCRIPTION
I delete Home link form navbar, because our page name is works like a Home a mean redirect is "/"